### PR TITLE
Undefined variable $count, $slider

### DIFF
--- a/envato-flex-slider.php
+++ b/envato-flex-slider.php
@@ -1,100 +1,85 @@
 <?php
-
 /*
 Plugin Name: Envato FlexSlider
-Plugin URI: 
+Plugin URI:
 Description: A simple plugin that integrates FlexSlider (http://flex.madebymufffin.com/) with WordPress using custom post types!
 Author: Joe Casabona
-Version: 0.8
+Version: 0.5
 Author URI: http://www.casabona.org
 */
 
 /*Some Set-up*/
-define('EFS_PATH', WP_PLUGIN_URL . '/' . plugin_basename( dirname(__FILE__) ) . '/' );
+define('EFS_PATH', get_template_directory_uri() . '/inc/vendors/' . basename( dirname(__FILE__) ) . '/' );
 define('EFS_NAME', "Envato FlexSlider");
-define ("EFS_VERSION", "0.8");
+define ("EFS_VERSION", "0.5");
 
 /*Files to Include*/
 require_once('slider-img-type.php');
 
-
-/*Add the Javascript/CSS Files!*/
-wp_enqueue_script('flexslider', EFS_PATH.'jquery.flexslider-min.js', array('jquery'));
-wp_enqueue_style('flexslider_css', EFS_PATH.'flexslider.css');
-
-
-/*Add the Hooks to place the javascript in the header*/
-
-function efs_script(){
-
-print '<script type="text/javascript" charset="utf-8">
-  jQuery(window).load(function() {
-    jQuery(\'.flexslider\').flexslider();
-  });
-</script>';
-
-}
-
-add_action('wp_head', 'efs_script');
-
 function efs_get_slider(){
-
-/**Options Array...to be added on admin later...*/
-$showTitle= true;
-$showText= true;
-$beforeTitle= "<strong>";
-$afterTitle= "</strong>"; 
-	
-	$slider= '<div class="flexslider contain">
-	  <ul class="slides">';
-
-	$efs_query= "post_type=slider-image";
+	$efs_query = "post_type=slider-image";
 	query_posts($efs_query);
 	
+	global $post_id;
 	
-	if (have_posts()) : while (have_posts()) : the_post(); 
-		$img= get_the_post_thumbnail( $post->ID, 'large' );
+	if (have_posts()) : 	
 		
-		$slider.='<li>'.$img;
-		if($showTitle || $showText){
-			$slider.= '<p class="flex-caption">';
-			$slider.= ($showTitle) ? $beforeTitle. get_the_title() .$afterTitle : '';
-			$slider.= ($showText) ? '<br/>'.get_the_content() : ''; 
-			$slider.='</p>';
-		}
-		$slider.= '</li>';
+		$slider = '<div class="orbit" role="region" aria-label="Banner Slider" data-orbit data-options="animInFromLeft:fade-in; animInFromRight:fade-in; animOutToLeft:fade-out; animOutToRight:fade-out;">
+					<ul class="orbit-container">';		
+		
+		$count = 0;
+		$x = 1;
+		while (have_posts()) : the_post();
+			$count++;
+		endwhile;
+
+		while (have_posts()) : the_post();
+			$img = get_the_post_thumbnail($post_id, 'full', array( 'class' => 'orbit-image' ));
 			
-	endwhile; endif; wp_reset_query();
+  		$slide_link = slider_link_get_meta_box_data(get_the_ID());
+			$caption = get_the_title();
 
+			if ($x > $count) {
+				$x = 1;
+			}
+			$slider.= $post_id.'<li class="orbit-slide is-active"><div class="orbit-slide-number"><span>'.$x.'</span> of <span>'.$count.'</span></div><a href="'.$slide_link.'">'.$img.'</a><figcaption class="orbit-caption">'.$caption.'</figcaption></li>';
+			$x++;
+		endwhile;
 
-	$slider.= '</ul>
-	</div>';
-	
+		if($count > 1) {
+			$slider .= '<button class="orbit-previous"><span class="show-for-sr">Previous Slide</span>&#9664;&#xFE0E;</button>
+						<button class="orbit-next"><span class="show-for-sr">Next Slide</span>&#9654;&#xFE0E;</button>';
+		}
+	endif;
+	wp_reset_query();
+
+	if($count > 1) {
+		$slider .= '</ul>
+		<nav class="orbit-bullets">';
+
+		for ($x=0; $x < $count ; $x++) { 
+			$class = ($x == 0) ? 'is-active' : '' ;
+			$slider .= '<button class="'.$class.'" data-slide="'.$x.'"><span class="show-for-sr">Current Slide</span></button>';
+		}
+
+		$slider .= '</div></nav>';
+	} else {
+		$slider .= '</ul></div>';
+	}
+
 	return $slider;
 }
 
-
 /**add the shortcode for the slider- for use in editor**/
-
-function efs_insert_slider($atts, $content=null){
-
-$slider= efs_get_slider();
-
-return $slider;
-
+function efs_insert_slider($atts, $content=null) {
+	$slider= efs_get_slider();
+	return $slider;
 }
-
-
 add_shortcode('ef_slider', 'efs_insert_slider');
 
-
-
 /**add template tag- for use in themes**/
-
-function efs_slider(){
-
+function efs_slider() {
 	print efs_get_slider();
 }
-
 
 ?>

--- a/envato-flex-slider.php
+++ b/envato-flex-slider.php
@@ -8,78 +8,76 @@ Version: 0.5
 Author URI: http://www.casabona.org
 */
 
-/*Some Set-up*/
-define('EFS_PATH', get_template_directory_uri() . '/inc/vendors/' . basename( dirname(__FILE__) ) . '/' );
+/* Some Set-up */
+define('EFS_PATH', get_template_directory_uri() . '/inc/vendors/' . basename(dirname(__FILE__)) . '/');
 define('EFS_NAME', "Envato FlexSlider");
-define ("EFS_VERSION", "0.5");
+define("EFS_VERSION", "0.5");
 
-/*Files to Include*/
+/* Files to Include */
 require_once('slider-img-type.php');
 
-function efs_get_slider(){
-	$efs_query = "post_type=slider-image";
-	query_posts($efs_query);
-	
-	global $post_id;
-	
-	if (have_posts()) : 	
-		
-		$slider = '<div class="orbit" role="region" aria-label="Banner Slider" data-orbit data-options="animInFromLeft:fade-in; animInFromRight:fade-in; animOutToLeft:fade-out; animOutToRight:fade-out;">
-					<ul class="orbit-container">';		
-		
-		$count = 0;
-		$x = 1;
-		while (have_posts()) : the_post();
-			$count++;
-		endwhile;
+function efs_get_slider() {
+  $args = array(
+    'post_type' => 'slider-image',
+    'posts_per_page' => -1 // Get all posts
+  );
+  $query = new WP_Query($args);
 
-		while (have_posts()) : the_post();
-			$img = get_the_post_thumbnail($post_id, 'full', array( 'class' => 'orbit-image' ));
-			
-  		$slide_link = slider_link_get_meta_box_data(get_the_ID());
-			$caption = get_the_title();
+  global $post_id;
 
-			if ($x > $count) {
-				$x = 1;
-			}
-			$slider.= $post_id.'<li class="orbit-slide is-active"><div class="orbit-slide-number"><span>'.$x.'</span> of <span>'.$count.'</span></div><a href="'.$slide_link.'">'.$img.'</a><figcaption class="orbit-caption">'.$caption.'</figcaption></li>';
-			$x++;
-		endwhile;
+  if ($query->have_posts()) {
+    $count = $query->post_count;
+    $slider = '<div class="orbit" role="region" aria-label="Banner Slider" data-orbit data-options="animInFromLeft:fade-in; animInFromRight:fade-in; animOutToLeft:fade-out; animOutToRight:fade-out;">
+                <ul class="orbit-container">';
 
-		if($count > 1) {
-			$slider .= '<button class="orbit-previous"><span class="show-for-sr">Previous Slide</span>&#9664;&#xFE0E;</button>
-						<button class="orbit-next"><span class="show-for-sr">Next Slide</span>&#9654;&#xFE0E;</button>';
-		}
-	endif;
-	wp_reset_query();
+    $x = 1;
+    while ($query->have_posts()) {
+      $query->the_post();
+      $img = get_the_post_thumbnail(get_the_ID(), 'full', array('class' => 'orbit-image'));
+      $slide_link = slider_link_get_meta_box_data(get_the_ID());
+      $caption = get_the_title();
 
-	if($count > 1) {
-		$slider .= '</ul>
-		<nav class="orbit-bullets">';
+      $class = ($x == 1) ? 'is-active' : '';
+      $slider .= '<li class="orbit-slide ' . $class . '"><div class="orbit-slide-number"><span>' . $x . '</span> of <span>' . $count . '</span></div><a href="' . $slide_link . '">' . $img . '</a><figcaption class="orbit-caption">' . $caption . '</figcaption></li>';
+      $x++;
+    }
 
-		for ($x=0; $x < $count ; $x++) { 
-			$class = ($x == 0) ? 'is-active' : '' ;
-			$slider .= '<button class="'.$class.'" data-slide="'.$x.'"><span class="show-for-sr">Current Slide</span></button>';
-		}
+    if ($count > 1) {
+      $slider .= '<button class="orbit-previous"><span class="show-for-sr">Previous Slide</span>&#9664;&#xFE0E;</button>
+                  <button class="orbit-next"><span class="show-for-sr">Next Slide</span>&#9654;&#xFE0E;</button>';
+    }
+    
+    $slider .= '</ul>';
+    
+    if ($count > 1) {
+      $slider .= '<nav class="orbit-bullets">';
+      for ($i = 0; $i < $count; $i++) {
+        $class = ($i == 0) ? 'is-active' : '';
+        $slider .= '<button class="' . $class . '" data-slide="' . $i . '"><span class="show-for-sr">Current Slide</span></button>';
+      }
+      $slider .= '</nav>';
+    }
 
-		$slider .= '</div></nav>';
-	} else {
-		$slider .= '</ul></div>';
-	}
+    $slider .= '</div>';
 
-	return $slider;
+    wp_reset_postdata(); // Reset the query data
+
+    return $slider;
+  } else {
+    return;
+  }
 }
 
-/**add the shortcode for the slider- for use in editor**/
-function efs_insert_slider($atts, $content=null) {
-	$slider= efs_get_slider();
-	return $slider;
+/** Add the shortcode for the slider - for use in editor **/
+function efs_insert_slider($atts, $content = null) {
+  $slider = efs_get_slider();
+  return $slider;
 }
 add_shortcode('ef_slider', 'efs_insert_slider');
 
-/**add template tag- for use in themes**/
+/** Add template tag - for use in themes **/
 function efs_slider() {
-	print efs_get_slider();
+  echo efs_get_slider();
 }
 
 ?>

--- a/flexslider.css
+++ b/flexslider.css
@@ -1,34 +1,25 @@
 /*
- * jQuery FlexSlider v2.0
- * http://www.woothemes.com/flexslider/
+ * jQuery FlexSlider v1.7
+ * http://flex.madebymufffin.com
  *
- * Copyright 2012 WooThemes
- * Free to use under the GPLv2 license.
- * http://www.gnu.org/licenses/gpl-2.0.html
- *
- * Contributing author: Tyler Smith (@mbmufffin)
+ * Copyright 2011, Tyler Smith
+ * Free to use under the MIT license.
+ * http://www.opensource.org/licenses/mit-license.php
  */
 
- 
 /* Browser Resets */
 .flex-container a:active,
-.flexslider a:active,
-.flex-container a:focus,
-.flexslider a:focus  {outline: none;}
+.flexslider a:active {outline: none;}
 .slides,
 .flex-control-nav,
 .flex-direction-nav {margin: 0; padding: 0; list-style: none;} 
 
 /* FlexSlider Necessary Styles
 *********************************/ 
-.flexslider {margin: 0; padding: 0;}
-.flexslider .slides > li {display: none; -webkit-backface-visibility: hidden; margin: 0;} /* Hide the slides before the JS is loaded. Avoids image jumping */
-.flexslider .slides img {width: 100%; display: block; padding: 0; margin: 0;}
-#wrapper .flexslider .slides p{ background: rgba(0,0,0,0.5); color: #FFFFFF; padding: 17px; margin: 15px 0; position: relative; z-index: 4; margin-top: -5.2%;}
-.flexslider .slides p a{ color: #ecd5ca; }
-
+.flexslider {width: 100%; margin: 0; padding: 0;}
+.flexslider .slides > li {display: none;} /* Hide the slides before the JS is loaded. Avoids image jumping */
+.flexslider .slides img {width: 100%; display: block;}
 .flex-pauseplay span {text-transform: capitalize;}
-
 
 /* Clearfix for the .slides element */
 .slides:after {content: "."; display: block; clear: both; visibility: hidden; line-height: 0; height: 0;} 
@@ -43,38 +34,42 @@ html[xmlns] .slides {display: block;}
 
 /* FlexSlider Default Theme
 *********************************/
-.flexslider {margin: 0 0 60px;}
-.flex-viewport {max-height: 2000px; -webkit-transition: all 1s ease; -moz-transition: all 1s ease; transition: all 1s ease;}
-.loading .flex-viewport {max-height: 300px;}
+.flexslider {position: relative; zoom: 1;}
 .flexslider .slides {zoom: 1;}
+.flexslider .slides > li {position: relative;}
+/* Suggested container for "Slide" animation setups. Can replace this with your own, if you wish */
+.flex-container {zoom: 1; position: relative;}
 
-.carousel li {margin-right: 5px}
-
+/* Caption style - taken from Orbit */
+.flex-caption {
+        position: absolute;
+        bottom: -17px;
+        background-color: rgba(51, 51, 51, 0.7);
+        color: white;
+        width: 100%;
+        height: 40px;
+        padding: 0.625rem 0.875rem;
+        font-size: 0.865rem; }
 
 /* Direction Nav */
-.flex-direction-nav {*height: 0;}
-.flex-direction-nav a {width: 30px; height: 30px; margin: -20px 0 0; display: block; background: url(images/bg_direction_nav.png) no-repeat 0 0; position: absolute; top: 35%; z-index: 10; cursor: pointer; text-indent: -9999px; opacity: 0; -webkit-transition: all .3s ease;}
-.flex-direction-nav .flex-next {background-position: 100% 0; right: -36px; }
-.flex-direction-nav .flex-prev {left: -36px;}
-.flexslider:hover .flex-next {opacity: 0.8; right: 5px;}
-.flexslider:hover .flex-prev {opacity: 0.8; left: 5px;}
-.flexslider:hover .flex-next:hover, .flexslider:hover .flex-prev:hover {opacity: 1;}
-.flex-direction-nav .flex-disabled {opacity: .3!important; filter:alpha(opacity=30); cursor: default;}
+.flex-direction-nav li a {width: 67px; height: 65px; margin: -20px 0 0; display: block; background: url(theme/bg_direction_nav_orbit.png) no-repeat 0 0; position: absolute; top: 50%; cursor: pointer; text-indent: -9999px;}
+.flex-direction-nav li a.next {background-position: -52px 0; right: -15px;}
+.flex-direction-nav li a.prev {background-position: 0 0; left: 0px; width: 50px;}
+.flex-direction-nav li a.disabled {opacity: .3; filter:alpha(opacity=30); cursor: default;}
 
 /* Control Nav */
-.flex-control-nav {width: 100%; position: absolute; bottom: -40px; text-align: center;}
-.flex-control-nav li {margin: 0 6px; display: inline-block; zoom: 1; *display: inline;}
-.flex-control-paging li a {width: 11px; height: 11px; display: block; background: #666; background: rgba(0,0,0,0.5); cursor: pointer; text-indent: -9999px; -webkit-border-radius: 20px; -moz-border-radius: 20px; -o-border-radius: 20px; border-radius: 20px; box-shadow: inset 0 0 3px rgba(0,0,0,0.3);}
-.flex-control-paging li a:hover { background: #333; background: rgba(0,0,0,0.7); }
-.flex-control-paging li a.flex-active { background: #000; background: rgba(0,0,0,0.9); cursor: default; }
+/*.flex-control-nav {width: 100%; position: absolute; bottom: -30px; text-align: center;}*/
+.flex-control-nav {width: 100%; position: absolute; top: 16px; left: 15px;}
+.flex-control-nav li {margin: 0 0 0 5px; display: inline-block; zoom: 1; *display: inline;}
+.flex-control-nav li:first-child {margin: 0;}
+.flex-control-nav li a {width: 13px; height: 13px; display: block; background: url(theme/bg_control_nav.png) no-repeat 0 0; cursor: pointer; text-indent: -9999px;}
+.flex-control-nav li a:hover {background-position: 0 -13px;}
+.flex-control-nav li a.active {background-position: 0 -26px; cursor: default;}
 
-.flex-control-thumbs {margin: 5px 0 0; position: static; overflow: hidden;}
-.flex-control-thumbs li {width: 25%; float: left; margin: 0;}
-.flex-control-thumbs img {width: 100%; display: block; opacity: .7; cursor: pointer;}
-.flex-control-thumbs img:hover {opacity: 1;}
-.flex-control-thumbs .flex-active {opacity: 1; cursor: default;}
+.flexslider > ul > li > img {
+  width: 100%;
+}
 
-@media screen and (max-width: 860px) {
-  .flex-direction-nav .flex-prev {opacity: 1; left: 0;}
-  .flex-direction-nav .flex-next {opacity: 1; right: 0;}
+.govph-flexslider {
+  margin: 30px 0 40px 0;
 }

--- a/jquery.flexslider-min.js
+++ b/jquery.flexslider-min.js
@@ -1,43 +1,114 @@
 /*
- * jQuery FlexSlider v2.1
- * http://www.woothemes.com/flexslider/
- *
- * Copyright 2012 WooThemes
- * Free to use under the GPLv2 license.
- * http://www.gnu.org/licenses/gpl-2.0.html
- *
- * Contributing author: Tyler Smith (@mbmufffin)
+ * jQuery FlexSlider v1.7
+ * http://flex.madebymufffin.com
+ * Copyright 2011, Tyler Smith
+ * Free to use under the MIT license.
  */
-(function(d){d.flexslider=function(j,l){var a=d(j),c=d.extend({},d.flexslider.defaults,l),e=c.namespace,q="ontouchstart"in window||window.DocumentTouch&&document instanceof DocumentTouch,u=q?"touchend":"click",m="vertical"===c.direction,n=c.reverse,h=0<c.itemWidth,s="fade"===c.animation,t=""!==c.asNavFor,f={};d.data(j,"flexslider",a);f={init:function(){a.animating=!1;a.currentSlide=c.startAt;a.animatingTo=a.currentSlide;a.atEnd=0===a.currentSlide||a.currentSlide===a.last;a.containerSelector=c.selector.substr(0,
-c.selector.search(" "));a.slides=d(c.selector,a);a.container=d(a.containerSelector,a);a.count=a.slides.length;a.syncExists=0<d(c.sync).length;"slide"===c.animation&&(c.animation="swing");a.prop=m?"top":"marginLeft";a.args={};a.manualPause=!1;var b=a,g;if(g=!c.video)if(g=!s)if(g=c.useCSS)a:{g=document.createElement("div");var p=["perspectiveProperty","WebkitPerspective","MozPerspective","OPerspective","msPerspective"],e;for(e in p)if(void 0!==g.style[p[e]]){a.pfx=p[e].replace("Perspective","").toLowerCase();
-a.prop="-"+a.pfx+"-transform";g=!0;break a}g=!1}b.transitions=g;""!==c.controlsContainer&&(a.controlsContainer=0<d(c.controlsContainer).length&&d(c.controlsContainer));""!==c.manualControls&&(a.manualControls=0<d(c.manualControls).length&&d(c.manualControls));c.randomize&&(a.slides.sort(function(){return Math.round(Math.random())-0.5}),a.container.empty().append(a.slides));a.doMath();t&&f.asNav.setup();a.setup("init");c.controlNav&&f.controlNav.setup();c.directionNav&&f.directionNav.setup();c.keyboard&&
-(1===d(a.containerSelector).length||c.multipleKeyboard)&&d(document).bind("keyup",function(b){b=b.keyCode;if(!a.animating&&(39===b||37===b))b=39===b?a.getTarget("next"):37===b?a.getTarget("prev"):!1,a.flexAnimate(b,c.pauseOnAction)});c.mousewheel&&a.bind("mousewheel",function(b,g){b.preventDefault();var d=0>g?a.getTarget("next"):a.getTarget("prev");a.flexAnimate(d,c.pauseOnAction)});c.pausePlay&&f.pausePlay.setup();c.slideshow&&(c.pauseOnHover&&a.hover(function(){!a.manualPlay&&!a.manualPause&&a.pause()},
-function(){!a.manualPause&&!a.manualPlay&&a.play()}),0<c.initDelay?setTimeout(a.play,c.initDelay):a.play());q&&c.touch&&f.touch();(!s||s&&c.smoothHeight)&&d(window).bind("resize focus",f.resize);setTimeout(function(){c.start(a)},200)},asNav:{setup:function(){a.asNav=!0;a.animatingTo=Math.floor(a.currentSlide/a.move);a.currentItem=a.currentSlide;a.slides.removeClass(e+"active-slide").eq(a.currentItem).addClass(e+"active-slide");a.slides.click(function(b){b.preventDefault();b=d(this);var g=b.index();
-!d(c.asNavFor).data("flexslider").animating&&!b.hasClass("active")&&(a.direction=a.currentItem<g?"next":"prev",a.flexAnimate(g,c.pauseOnAction,!1,!0,!0))})}},controlNav:{setup:function(){a.manualControls?f.controlNav.setupManual():f.controlNav.setupPaging()},setupPaging:function(){var b=1,g;a.controlNavScaffold=d('<ol class="'+e+"control-nav "+e+("thumbnails"===c.controlNav?"control-thumbs":"control-paging")+'"></ol>');if(1<a.pagingCount)for(var p=0;p<a.pagingCount;p++)g="thumbnails"===c.controlNav?
-'<img src="'+a.slides.eq(p).attr("data-thumb")+'"/>':"<a>"+b+"</a>",a.controlNavScaffold.append("<li>"+g+"</li>"),b++;a.controlsContainer?d(a.controlsContainer).append(a.controlNavScaffold):a.append(a.controlNavScaffold);f.controlNav.set();f.controlNav.active();a.controlNavScaffold.delegate("a, img",u,function(b){b.preventDefault();b=d(this);var g=a.controlNav.index(b);b.hasClass(e+"active")||(a.direction=g>a.currentSlide?"next":"prev",a.flexAnimate(g,c.pauseOnAction))});q&&a.controlNavScaffold.delegate("a",
-"click touchstart",function(a){a.preventDefault()})},setupManual:function(){a.controlNav=a.manualControls;f.controlNav.active();a.controlNav.live(u,function(b){b.preventDefault();b=d(this);var g=a.controlNav.index(b);b.hasClass(e+"active")||(g>a.currentSlide?a.direction="next":a.direction="prev",a.flexAnimate(g,c.pauseOnAction))});q&&a.controlNav.live("click touchstart",function(a){a.preventDefault()})},set:function(){a.controlNav=d("."+e+"control-nav li "+("thumbnails"===c.controlNav?"img":"a"),
-a.controlsContainer?a.controlsContainer:a)},active:function(){a.controlNav.removeClass(e+"active").eq(a.animatingTo).addClass(e+"active")},update:function(b,c){1<a.pagingCount&&"add"===b?a.controlNavScaffold.append(d("<li><a>"+a.count+"</a></li>")):1===a.pagingCount?a.controlNavScaffold.find("li").remove():a.controlNav.eq(c).closest("li").remove();f.controlNav.set();1<a.pagingCount&&a.pagingCount!==a.controlNav.length?a.update(c,b):f.controlNav.active()}},directionNav:{setup:function(){var b=d('<ul class="'+
-e+'direction-nav"><li><a class="'+e+'prev" href="#">'+c.prevText+'</a></li><li><a class="'+e+'next" href="#">'+c.nextText+"</a></li></ul>");a.controlsContainer?(d(a.controlsContainer).append(b),a.directionNav=d("."+e+"direction-nav li a",a.controlsContainer)):(a.append(b),a.directionNav=d("."+e+"direction-nav li a",a));f.directionNav.update();a.directionNav.bind(u,function(b){b.preventDefault();b=d(this).hasClass(e+"next")?a.getTarget("next"):a.getTarget("prev");a.flexAnimate(b,c.pauseOnAction)});
-q&&a.directionNav.bind("click touchstart",function(a){a.preventDefault()})},update:function(){var b=e+"disabled";1===a.pagingCount?a.directionNav.addClass(b):c.animationLoop?a.directionNav.removeClass(b):0===a.animatingTo?a.directionNav.removeClass(b).filter("."+e+"prev").addClass(b):a.animatingTo===a.last?a.directionNav.removeClass(b).filter("."+e+"next").addClass(b):a.directionNav.removeClass(b)}},pausePlay:{setup:function(){var b=d('<div class="'+e+'pauseplay"><a></a></div>');a.controlsContainer?
-(a.controlsContainer.append(b),a.pausePlay=d("."+e+"pauseplay a",a.controlsContainer)):(a.append(b),a.pausePlay=d("."+e+"pauseplay a",a));f.pausePlay.update(c.slideshow?e+"pause":e+"play");a.pausePlay.bind(u,function(b){b.preventDefault();d(this).hasClass(e+"pause")?(a.manualPause=!0,a.manualPlay=!1,a.pause()):(a.manualPause=!1,a.manualPlay=!0,a.play())});q&&a.pausePlay.bind("click touchstart",function(a){a.preventDefault()})},update:function(b){"play"===b?a.pausePlay.removeClass(e+"pause").addClass(e+
-"play").text(c.playText):a.pausePlay.removeClass(e+"play").addClass(e+"pause").text(c.pauseText)}},touch:function(){function b(b){k=m?d-b.touches[0].pageY:d-b.touches[0].pageX;q=m?Math.abs(k)<Math.abs(b.touches[0].pageX-e):Math.abs(k)<Math.abs(b.touches[0].pageY-e);if(!q||500<Number(new Date)-l)b.preventDefault(),!s&&a.transitions&&(c.animationLoop||(k/=0===a.currentSlide&&0>k||a.currentSlide===a.last&&0<k?Math.abs(k)/r+2:1),a.setProps(f+k,"setTouch"))}function g(){j.removeEventListener("touchmove",
-b,!1);if(a.animatingTo===a.currentSlide&&!q&&null!==k){var h=n?-k:k,m=0<h?a.getTarget("next"):a.getTarget("prev");a.canAdvance(m)&&(550>Number(new Date)-l&&50<Math.abs(h)||Math.abs(h)>r/2)?a.flexAnimate(m,c.pauseOnAction):s||a.flexAnimate(a.currentSlide,c.pauseOnAction,!0)}j.removeEventListener("touchend",g,!1);f=k=e=d=null}var d,e,f,r,k,l,q=!1;j.addEventListener("touchstart",function(k){a.animating?k.preventDefault():1===k.touches.length&&(a.pause(),r=m?a.h:a.w,l=Number(new Date),f=h&&n&&a.animatingTo===
-a.last?0:h&&n?a.limit-(a.itemW+c.itemMargin)*a.move*a.animatingTo:h&&a.currentSlide===a.last?a.limit:h?(a.itemW+c.itemMargin)*a.move*a.currentSlide:n?(a.last-a.currentSlide+a.cloneOffset)*r:(a.currentSlide+a.cloneOffset)*r,d=m?k.touches[0].pageY:k.touches[0].pageX,e=m?k.touches[0].pageX:k.touches[0].pageY,j.addEventListener("touchmove",b,!1),j.addEventListener("touchend",g,!1))},!1)},resize:function(){!a.animating&&a.is(":visible")&&(h||a.doMath(),s?f.smoothHeight():h?(a.slides.width(a.computedW),
-a.update(a.pagingCount),a.setProps()):m?(a.viewport.height(a.h),a.setProps(a.h,"setTotal")):(c.smoothHeight&&f.smoothHeight(),a.newSlides.width(a.computedW),a.setProps(a.computedW,"setTotal")))},smoothHeight:function(b){if(!m||s){var c=s?a:a.viewport;b?c.animate({height:a.slides.eq(a.animatingTo).height()},b):c.height(a.slides.eq(a.animatingTo).height())}},sync:function(b){var g=d(c.sync).data("flexslider"),e=a.animatingTo;switch(b){case "animate":g.flexAnimate(e,c.pauseOnAction,!1,!0);break;case "play":!g.playing&&
-!g.asNav&&g.play();break;case "pause":g.pause()}}};a.flexAnimate=function(b,g,p,j,l){t&&1===a.pagingCount&&(a.direction=a.currentItem<b?"next":"prev");if(!a.animating&&(a.canAdvance(b,l)||p)&&a.is(":visible")){if(t&&j)if(p=d(c.asNavFor).data("flexslider"),a.atEnd=0===b||b===a.count-1,p.flexAnimate(b,!0,!1,!0,l),a.direction=a.currentItem<b?"next":"prev",p.direction=a.direction,Math.ceil((b+1)/a.visible)-1!==a.currentSlide&&0!==b)a.currentItem=b,a.slides.removeClass(e+"active-slide").eq(b).addClass(e+
-"active-slide"),b=Math.floor(b/a.visible);else return a.currentItem=b,a.slides.removeClass(e+"active-slide").eq(b).addClass(e+"active-slide"),!1;a.animating=!0;a.animatingTo=b;c.before(a);g&&a.pause();a.syncExists&&!l&&f.sync("animate");c.controlNav&&f.controlNav.active();h||a.slides.removeClass(e+"active-slide").eq(b).addClass(e+"active-slide");a.atEnd=0===b||b===a.last;c.directionNav&&f.directionNav.update();b===a.last&&(c.end(a),c.animationLoop||a.pause());if(s)q?(a.slides.eq(a.currentSlide).css({opacity:0,
-zIndex:1}),a.slides.eq(b).css({opacity:1,zIndex:2}),a.slides.unbind("webkitTransitionEnd transitionend"),a.slides.eq(a.currentSlide).bind("webkitTransitionEnd transitionend",function(){c.after(a)}),a.animating=!1,a.currentSlide=a.animatingTo):(a.slides.eq(a.currentSlide).fadeOut(c.animationSpeed,c.easing),a.slides.eq(b).fadeIn(c.animationSpeed,c.easing,a.wrapup));else{var r=m?a.slides.filter(":first").height():a.computedW;h?(b=c.itemWidth>a.w?2*c.itemMargin:c.itemMargin,b=(a.itemW+b)*a.move*a.animatingTo,
-b=b>a.limit&&1!==a.visible?a.limit:b):b=0===a.currentSlide&&b===a.count-1&&c.animationLoop&&"next"!==a.direction?n?(a.count+a.cloneOffset)*r:0:a.currentSlide===a.last&&0===b&&c.animationLoop&&"prev"!==a.direction?n?0:(a.count+1)*r:n?(a.count-1-b+a.cloneOffset)*r:(b+a.cloneOffset)*r;a.setProps(b,"",c.animationSpeed);if(a.transitions){if(!c.animationLoop||!a.atEnd)a.animating=!1,a.currentSlide=a.animatingTo;a.container.unbind("webkitTransitionEnd transitionend");a.container.bind("webkitTransitionEnd transitionend",
-function(){a.wrapup(r)})}else a.container.animate(a.args,c.animationSpeed,c.easing,function(){a.wrapup(r)})}c.smoothHeight&&f.smoothHeight(c.animationSpeed)}};a.wrapup=function(b){!s&&!h&&(0===a.currentSlide&&a.animatingTo===a.last&&c.animationLoop?a.setProps(b,"jumpEnd"):a.currentSlide===a.last&&(0===a.animatingTo&&c.animationLoop)&&a.setProps(b,"jumpStart"));a.animating=!1;a.currentSlide=a.animatingTo;c.after(a)};a.animateSlides=function(){a.animating||a.flexAnimate(a.getTarget("next"))};a.pause=
-function(){clearInterval(a.animatedSlides);a.playing=!1;c.pausePlay&&f.pausePlay.update("play");a.syncExists&&f.sync("pause")};a.play=function(){a.animatedSlides=setInterval(a.animateSlides,c.slideshowSpeed);a.playing=!0;c.pausePlay&&f.pausePlay.update("pause");a.syncExists&&f.sync("play")};a.canAdvance=function(b,g){var d=t?a.pagingCount-1:a.last;return g?!0:t&&a.currentItem===a.count-1&&0===b&&"prev"===a.direction?!0:t&&0===a.currentItem&&b===a.pagingCount-1&&"next"!==a.direction?!1:b===a.currentSlide&&
-!t?!1:c.animationLoop?!0:a.atEnd&&0===a.currentSlide&&b===d&&"next"!==a.direction?!1:a.atEnd&&a.currentSlide===d&&0===b&&"next"===a.direction?!1:!0};a.getTarget=function(b){a.direction=b;return"next"===b?a.currentSlide===a.last?0:a.currentSlide+1:0===a.currentSlide?a.last:a.currentSlide-1};a.setProps=function(b,g,d){var e,f=b?b:(a.itemW+c.itemMargin)*a.move*a.animatingTo;e=-1*function(){if(h)return"setTouch"===g?b:n&&a.animatingTo===a.last?0:n?a.limit-(a.itemW+c.itemMargin)*a.move*a.animatingTo:a.animatingTo===
-a.last?a.limit:f;switch(g){case "setTotal":return n?(a.count-1-a.currentSlide+a.cloneOffset)*b:(a.currentSlide+a.cloneOffset)*b;case "setTouch":return b;case "jumpEnd":return n?b:a.count*b;case "jumpStart":return n?a.count*b:b;default:return b}}()+"px";a.transitions&&(e=m?"translate3d(0,"+e+",0)":"translate3d("+e+",0,0)",d=void 0!==d?d/1E3+"s":"0s",a.container.css("-"+a.pfx+"-transition-duration",d));a.args[a.prop]=e;(a.transitions||void 0===d)&&a.container.css(a.args)};a.setup=function(b){if(s)a.slides.css({width:"100%",
-"float":"left",marginRight:"-100%",position:"relative"}),"init"===b&&(q?a.slides.css({opacity:0,display:"block",webkitTransition:"opacity "+c.animationSpeed/1E3+"s ease",zIndex:1}).eq(a.currentSlide).css({opacity:1,zIndex:2}):a.slides.eq(a.currentSlide).fadeIn(c.animationSpeed,c.easing)),c.smoothHeight&&f.smoothHeight();else{var g,p;"init"===b&&(a.viewport=d('<div class="'+e+'viewport"></div>').css({overflow:"hidden",position:"relative"}).appendTo(a).append(a.container),a.cloneCount=0,a.cloneOffset=
-0,n&&(p=d.makeArray(a.slides).reverse(),a.slides=d(p),a.container.empty().append(a.slides)));c.animationLoop&&!h&&(a.cloneCount=2,a.cloneOffset=1,"init"!==b&&a.container.find(".clone").remove(),a.container.append(a.slides.first().clone().addClass("clone")).prepend(a.slides.last().clone().addClass("clone")));a.newSlides=d(c.selector,a);g=n?a.count-1-a.currentSlide+a.cloneOffset:a.currentSlide+a.cloneOffset;m&&!h?(a.container.height(200*(a.count+a.cloneCount)+"%").css("position","absolute").width("100%"),
-setTimeout(function(){a.newSlides.css({display:"block"});a.doMath();a.viewport.height(a.h);a.setProps(g*a.h,"init")},"init"===b?100:0)):(a.container.width(200*(a.count+a.cloneCount)+"%"),a.setProps(g*a.computedW,"init"),setTimeout(function(){a.doMath();a.newSlides.css({width:a.computedW,"float":"left",display:"block"});c.smoothHeight&&f.smoothHeight()},"init"===b?100:0))}h||a.slides.removeClass(e+"active-slide").eq(a.currentSlide).addClass(e+"active-slide")};a.doMath=function(){var b=a.slides.first(),
-d=c.itemMargin,e=c.minItems,f=c.maxItems;a.w=a.width();a.h=b.height();a.boxPadding=b.outerWidth()-b.width();h?(a.itemT=c.itemWidth+d,a.minW=e?e*a.itemT:a.w,a.maxW=f?f*a.itemT:a.w,a.itemW=a.minW>a.w?(a.w-d*e)/e:a.maxW<a.w?(a.w-d*f)/f:c.itemWidth>a.w?a.w:c.itemWidth,a.visible=Math.floor(a.w/(a.itemW+d)),a.move=0<c.move&&c.move<a.visible?c.move:a.visible,a.pagingCount=Math.ceil((a.count-a.visible)/a.move+1),a.last=a.pagingCount-1,a.limit=1===a.pagingCount?0:c.itemWidth>a.w?(a.itemW+2*d)*a.count-a.w-
-d:(a.itemW+d)*a.count-a.w-d):(a.itemW=a.w,a.pagingCount=a.count,a.last=a.count-1);a.computedW=a.itemW-a.boxPadding};a.update=function(b,d){a.doMath();h||(b<a.currentSlide?a.currentSlide+=1:b<=a.currentSlide&&0!==b&&(a.currentSlide-=1),a.animatingTo=a.currentSlide);if(c.controlNav&&!a.manualControls)if("add"===d&&!h||a.pagingCount>a.controlNav.length)f.controlNav.update("add");else if("remove"===d&&!h||a.pagingCount<a.controlNav.length)h&&a.currentSlide>a.last&&(a.currentSlide-=1,a.animatingTo-=1),
-f.controlNav.update("remove",a.last);c.directionNav&&f.directionNav.update()};a.addSlide=function(b,e){var f=d(b);a.count+=1;a.last=a.count-1;m&&n?void 0!==e?a.slides.eq(a.count-e).after(f):a.container.prepend(f):void 0!==e?a.slides.eq(e).before(f):a.container.append(f);a.update(e,"add");a.slides=d(c.selector+":not(.clone)",a);a.setup();c.added(a)};a.removeSlide=function(b){var e=isNaN(b)?a.slides.index(d(b)):b;a.count-=1;a.last=a.count-1;isNaN(b)?d(b,a.slides).remove():m&&n?a.slides.eq(a.last).remove():
-a.slides.eq(b).remove();a.doMath();a.update(e,"remove");a.slides=d(c.selector+":not(.clone)",a);a.setup();c.removed(a)};f.init()};d.flexslider.defaults={namespace:"flex-",selector:".slides > li",animation:"fade",easing:"swing",direction:"horizontal",reverse:!1,animationLoop:!0,smoothHeight:!1,startAt:0,slideshow:!0,slideshowSpeed:7E3,animationSpeed:600,initDelay:0,randomize:!1,pauseOnAction:!0,pauseOnHover:!1,useCSS:!0,touch:!0,video:!1,controlNav:!0,directionNav:!0,prevText:"Previous",nextText:"Next",
-keyboard:!0,multipleKeyboard:!1,mousewheel:!1,pausePlay:!1,pauseText:"Pause",playText:"Play",controlsContainer:"",manualControls:"",sync:"",asNavFor:"",itemWidth:0,itemMargin:0,minItems:0,maxItems:0,move:0,start:function(){},before:function(){},after:function(){},end:function(){},added:function(){},removed:function(){}};d.fn.flexslider=function(j){void 0===j&&(j={});if("object"===typeof j)return this.each(function(){var a=d(this),c=a.find(j.selector?j.selector:".slides > li");1===c.length?(c.fadeIn(400),
-j.start&&j.start(a)):void 0==a.data("flexslider")&&new d.flexslider(this,j)});var l=d(this).data("flexslider");switch(j){case "play":l.play();break;case "pause":l.pause();break;case "next":l.flexAnimate(l.getTarget("next"),!0);break;case "prev":case "previous":l.flexAnimate(l.getTarget("prev"),!0);break;default:"number"===typeof j&&l.flexAnimate(j,!0)}}})(jQuery);
+(function(a){
+	a.flexslider=function(c,b){
+		var d=c;d.init=function(){
+			d.vars=a.extend({},a.flexslider.defaults,b);
+			d.data("flexslider",true);
+			d.container=a(".slides",d);
+			d.slides=a(".slides > li",d);
+			d.count=d.slides.length;
+			d.animating=false;
+			d.currentSlide=d.vars.slideToStart;
+			d.atEnd=(d.currentSlide==0)?true:false;
+			d.eventType=("ontouchstart" in document.documentElement)?"touchstart":"click";
+			d.cloneCount=0;d.cloneOffset=0;
+			if(d.vars.controlsContainer!=""){
+				d.controlsContainer=a(d.vars.controlsContainer).eq(a(".slides").index(d.container));
+				d.containerExists=d.controlsContainer.length>0
+			}
+			if(d.vars.manualControls!=""){
+				d.manualControls=a(d.vars.manualControls,((d.containerExists)?d.controlsContainer:d));
+				d.manualExists=d.manualControls.length>0
+			}
+			if(d.vars.randomize){
+				d.slides.sort(function(){return(Math.round(Math.random())-0.5)});
+				d.container.empty().append(d.slides)
+			}
+			if(d.vars.animation.toLowerCase()=="slide"){
+				d.css({overflow:"hidden"});
+				if(d.vars.animationLoop){
+					d.cloneCount=2;
+					d.cloneOffset=1;
+					d.container.append(d.slides.filter(":first").clone().addClass("clone")).prepend(d.slides.filter(":last").clone().addClass("clone"))
+				}
+				d.container.width(((d.count+d.cloneCount)*d.width())+2000);
+				d.newSlides=a(".slides > li",d);
+				setTimeout(function(){d.newSlides.width(d.width()).css({"float":"left"}).show()},100);
+				d.container.css({marginLeft:(-1*(d.currentSlide+d.cloneOffset))*d.width()+"px"})
+			}else{
+				d.slides.css({width:"100%","float":"left",marginRight:"-100%"}).filter(":first").fadeIn(400,function(){})
+			}
+			if(d.vars.controlNav){
+				if(d.manualExists){d.controlNav=d.manualControls}else{var g=a('<ol class="flex-control-nav"></ol>');
+					var k=1;
+					for(var l=0;l<d.count;l++){
+						g.append("<li><a>"+k+"</a></li>");
+						k++
+					}
+					if(d.containerExists){
+						a(d.controlsContainer).append(g);d.controlNav=a(".flex-control-nav li a",d.controlsContainer)
+					}else{
+						d.append(g);d.controlNav=a(".flex-control-nav li a",d)
+					}
+				}
+				d.controlNav.eq(d.currentSlide).addClass("active");
+				d.controlNav.bind(d.eventType,function(i){
+					i.preventDefault();
+					if(!a(this).hasClass("active")){
+						d.flexAnimate(d.controlNav.index(a(this)),d.vars.pauseOnAction)
+					}
+				})
+			}
+			if(d.vars.directionNav){
+				var f=a('<ul class="flex-direction-nav"><li><a class="prev" href="#">'+d.vars.prevText+'</a></li><li><a class="next" href="#">'+d.vars.nextText+"</a></li></ul>");
+				if(d.containerExists){
+					a(d.controlsContainer).append(f);
+					d.directionNav=a(".flex-direction-nav li a",d.controlsContainer)
+				}else{
+					d.append(f);d.directionNav=a(".flex-direction-nav li a",d)
+				}
+				if(!d.vars.animationLoop){
+					if(d.currentSlide==0){
+						d.directionNav.filter(".prev").addClass("disabled")
+					}else{
+						if(d.currentSlide==d.count-1){
+							d.directionNav.filter(".next").addClass("disabled")
+						}
+					}
+				}
+				d.directionNav.bind(d.eventType,function(i){
+					i.preventDefault();
+					var j=(a(this).hasClass("next"))?d.getTarget("next"):d.getTarget("prev");
+					if(d.canAdvance(j)){
+						d.flexAnimate(j,d.vars.pauseOnAction)
+					}
+				})
+			}
+			if(d.vars.keyboardNav&&a("ul.slides").length==1){
+				a(document).keyup(function(i){
+					if(d.animating){
+						return
+					}else{
+						if(i.keyCode!=39&&i.keyCode!=37){
+							return
+						}else{
+							if(i.keyCode==39){
+								var j=d.getTarget("next")
+							}else{
+								if(i.keyCode==37){
+									var j=d.getTarget("prev")
+								}
+							}
+							if(d.canAdvance(j)){
+								d.flexAnimate(j,d.vars.pauseOnAction)
+							}
+						}
+					}
+				})
+			}
+			if(d.vars.slideshow){if(d.vars.pauseOnHover&&d.vars.slideshow){d.hover(function(){d.pause()},function(){d.resume()})}d.animatedSlides=setInterval(d.animateSlides,d.vars.slideshowSpeed)}if(d.vars.pausePlay){var e=a('<div class="flex-pauseplay"><span></span></div>');if(d.containerExists){d.controlsContainer.append(e);d.pausePlay=a(".flex-pauseplay span",d.controlsContainer)}else{d.append(e);d.pausePlay=a(".flex-pauseplay li a",d)}var h=(d.vars.slideshow)?"pause":"play";d.pausePlay.addClass(h).text(h);d.pausePlay.click(function(i){i.preventDefault();(a(this).hasClass("pause"))?d.pause():d.resume()})}if(d.vars.touchSwipe&&"ontouchstart" in document.documentElement){d.each(function(){var i,j=20;isMoving=false;function o(){this.removeEventListener("touchmove",m);i=null;isMoving=false}function m(s){if(isMoving){var p=s.touches[0].pageX,q=i-p;if(Math.abs(q)>=j){o();var r=(q>0)?d.getTarget("next"):d.getTarget("prev");if(d.canAdvance(r)){d.flexAnimate(r,d.vars.pauseOnAction)}}}}function n(p){if(p.touches.length==1){i=p.touches[0].pageX;isMoving=true;this.addEventListener("touchmove",m,false)}}if("ontouchstart" in document.documentElement){this.addEventListener("touchstart",n,false)}})}if(d.vars.animation.toLowerCase()=="slide"){d.sliderTimer;a(window).resize(function(){d.newSlides.width(d.width());d.container.width(((d.count+d.cloneCount)*d.width())+2000);clearTimeout(d.sliderTimer);d.sliderTimer=setTimeout(function(){d.flexAnimate(d.currentSlide)},300)})}d.vars.start(d)};d.flexAnimate=function(f,e){if(!d.animating){d.animating=true;if(e){d.pause()}if(d.vars.controlNav){d.controlNav.removeClass("active").eq(f).addClass("active")}d.atEnd=(f==0||f==d.count-1)?true:false;if(!d.vars.animationLoop){if(f==0){d.directionNav.removeClass("disabled").filter(".prev").addClass("disabled")}else{if(f==d.count-1){d.directionNav.removeClass("disabled").filter(".next").addClass("disabled");d.pause();d.vars.end(d)}else{d.directionNav.removeClass("disabled")}}}d.vars.before(d);if(d.vars.animation.toLowerCase()=="slide"){if(d.currentSlide==0&&f==d.count-1&&d.vars.animationLoop){d.slideString="0px"}else{if(d.currentSlide==d.count-1&&f==0&&d.vars.animationLoop){d.slideString=(-1*(d.count+1))*d.slides.filter(":first").width()+"px"}else{d.slideString=(-1*(f+d.cloneOffset))*d.slides.filter(":first").width()+"px"}}d.container.animate({marginLeft:d.slideString},d.vars.animationDuration,function(){if(d.currentSlide==0&&f==d.count-1&&d.vars.animationLoop){d.container.css({marginLeft:(-1*d.count)*d.slides.filter(":first").width()+"px"})}else{if(d.currentSlide==d.count-1&&f==0&&d.vars.animationLoop){d.container.css({marginLeft:-1*d.slides.filter(":first").width()+"px"})}}d.animating=false;d.currentSlide=f;d.vars.after(d)})}else{d.slides.eq(d.currentSlide).fadeOut(d.vars.animationDuration);d.slides.eq(f).fadeIn(d.vars.animationDuration,function(){d.animating=false;d.currentSlide=f;d.vars.after(d)})}}};d.animateSlides=function(){if(!d.animating){var e=(d.currentSlide==d.count-1)?0:d.currentSlide+1;d.flexAnimate(e)}};d.pause=function(){clearInterval(d.animatedSlides);if(d.vars.pausePlay){d.pausePlay.removeClass("pause").addClass("play").text("play")}};d.resume=function(){d.animatedSlides=setInterval(d.animateSlides,d.vars.slideshowSpeed);if(d.vars.pausePlay){d.pausePlay.removeClass("play").addClass("pause").text("pause")}};d.canAdvance=function(e){if(!d.vars.animationLoop&&d.atEnd){if(d.currentSlide==0&&e==d.count-1&&d.direction!="next"){return false}else{if(d.currentSlide==d.count-1&&e==0&&d.direction=="next"){return false}else{return true}}}else{return true}};d.getTarget=function(e){d.direction=e;if(e=="next"){return(d.currentSlide==d.count-1)?0:d.currentSlide+1}else{return(d.currentSlide==0)?d.count-1:d.currentSlide-1}};d.init()};a.flexslider.defaults={animation:"fade",slideshow:true,slideshowSpeed:7000,animationDuration:600,directionNav:true,controlNav:true,keyboardNav:true,touchSwipe:true,prevText:"Previous",nextText:"Next",pausePlay:false,randomize:false,slideToStart:0,animationLoop:true,pauseOnAction:true,pauseOnHover:false,controlsContainer:"",manualControls:"",start:function(){},before:function(){},after:function(){},end:function(){}};a.fn.flexslider=function(b){return this.each(function(){if(a(this).find(".slides li").length==1){a(this).find(".slides li").fadeIn(400)}else{if(a(this).data("flexslider")!=true){new a.flexslider(a(this),b)}}})}})(jQuery);

--- a/slider-img-type.php
+++ b/slider-img-type.php
@@ -1,28 +1,113 @@
 <?php
-define('EFS_CPT_NAME', "Slider Images");
-define('EFS_SINGLE', "Slider Image");
-define('EFS_TYPE', "slider-image");
-define('EFS_THUMB_SIZE', 500);
+define('CPT_NAME', "Slider Images");
+define('CPT_SINGLE', "Slider Image");
+define('CPT_TYPE', "slider-image");
+define('CPT_THUMB_SIZE', 500);
 
 add_theme_support('post-thumbnails', array('slider-image'));  
   
 function efs_register() {  
     $args = array(  
-        'label' => __(EFS_CPT_NAME),  
-        'singular_label' => __(EFS_SINGLE),  
+        'label' => __(CPT_NAME),  
+        'singular_label' => __(CPT_SINGLE),  
         'public' => true,  
         'show_ui' => true,  
         'capability_type' => 'post',  
         'hierarchical' => false,  
         'rewrite' => true,  
-        'supports' => array('title', 'editor', 'thumbnail')  
+        'supports' => array('title', 'editor', 'thumbnail'),
+        'public' => false,  // it's not public, it shouldn't have it's own permalink, and so on
+        'publicly_queryable' => true,  // you should be able to query it
+        'show_ui' => true,  // you should be able to edit it in wp-admin
+        'exclude_from_search' => true,  // you should exclude it from search results
+        'show_in_nav_menus' => false,  // you shouldn't be able to add it to menus
+        'has_archive' => false,  // it shouldn't have archive page
+        'rewrite' => false,  // it shouldn't have rewrite rules
        );  
   
-    register_post_type(EFS_TYPE , $args );  
-    set_post_thumbnail_size(EFS_THUMB_SIZE);
-}  
-
+    register_post_type(CPT_TYPE , $args );  
+    set_post_thumbnail_size(CPT_THUMB_SIZE);
+}
 
 add_action('init', 'efs_register');
 
-?>
+function efs_disable_editor() {
+    remove_post_type_support( CPT_TYPE, 'editor' );
+}
+add_action('init', 'efs_disable_editor');
+
+/**
+ * Add meta box
+ *
+ * @param post $post The post object
+ * @link https://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes
+ */
+function slider_link_add_meta_boxes( $post ){
+  add_meta_box( 'slider_link_meta_box', __( 'Slider Link', 'efs_slider' ), 'slider_link_build_meta_box', CPT_TYPE, 'normal', 'low' );
+}
+add_action( 'add_meta_boxes_slider-image', 'slider_link_add_meta_boxes' );
+
+/**
+ * Build custom field meta box
+ *
+ * @param post $post The post object
+ */
+function slider_link_build_meta_box( $post ){
+  // make sure the form request comes from WordPress
+  wp_nonce_field( basename( __FILE__ ), 'slider_link_meta_box_nonce' );
+
+  // retrieve the _slider_link current value
+  $slider_link = get_post_meta( $post->ID, '_slider_link', true );
+  ?>
+  <div class='inside'>
+    <div>
+      <input type="text" name="slider_link" value="<?php echo $slider_link; ?>" style="width: 100%;" />
+      <p>Enter the URL Linked to the slider image if any.<br/>To link internal path copy the permalink without the base URL. e.g. <strong>/2017/10/03/article-link</strong><br/> To link to external path add http:// or https:// at the beginning of the URL. e.g. <strong>http://example.com</strong></p>
+    </div>
+
+  </div>
+  <?php
+}
+
+/**
+ * Store custom field meta box data
+ *
+ * @param int $post_id The post ID.
+ * @link https://codex.wordpress.org/Plugin_API/Action_Reference/save_post
+ */
+function slider_link_save_meta_box_data( $post_id ){
+  // verify meta box nonce
+  if ( !isset( $_POST['slider_link_meta_box_nonce'] ) || !wp_verify_nonce( $_POST['slider_link_meta_box_nonce'], basename( __FILE__ ) ) ){
+    return;
+  }
+  // return if autosave
+  if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ){
+    return;
+  }
+  // Check the user's permissions.
+  if ( ! current_user_can( 'edit_post', $post_id ) ){
+    return;
+  }
+
+  if ( isset( $_REQUEST['slider_link'] ) ) {
+    update_post_meta( $post_id, '_slider_link', sanitize_text_field( $_POST['slider_link'] ) );
+  }
+}
+add_action( 'save_post_slider-image', 'slider_link_save_meta_box_data' );
+
+function slider_link_get_meta_box_data($post_id){
+    // @todo: format the url into proper url
+    $slider_link = get_post_meta($post_id, '_slider_link', true);
+    if($slider_link == ''){
+        return '#';
+    }
+
+    if(substr($slider_link, 0, 7) == 'http://' || substr($slider_link, 0, 8) == 'https://'){
+        return $slider_link;
+    }
+    if(substr($slider_link, 0, 1) != '/'){
+        $slider_link = '/'.$slider_link;
+    }
+    return get_site_url().$slider_link;
+}
+


### PR DESCRIPTION
This fiixes these errors:
```
Warning: Undefined variable $count in /var/www/html/wordpress/wp-content/themes/gwt-wordpress/vendors/envato-flex-slider/envato-flex-slider.php on line 56

Warning: Undefined variable $slider in /var/www/html/wordpress/wp-content/themes/gwt-wordpress/vendors/envato-flex-slider/envato-flex-slider.php on line 67
```


The error occurs because :

1.)  The variable `$count` is being used outside the context where it was initialized. Specifically, the issue arises from the usage of `$count` after the```while (have_posts())``` loop, but before the query has been fully reset.

2.) Usage of `query_posts()` directly, which modifies the main query and can cause unexpected issues. Instead I used `WP_Query` for custom queries.

